### PR TITLE
Bugfix/fixed build step crashing on bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Download Beatmods Dependencies
 
-An action that downloads and extracts beatsaber mod dependencies using a mod's manifest file. Mods are pulled from https://beatmods.com/.
+An action that downloads and extracts Beat Saber mod dependencies using a mod's manifest file. Mods are pulled from https://beatmods.com/.
+Manifest is expected to be UTF-8 encoded.
 
 ## Usage
 

--- a/main.js
+++ b/main.js
@@ -13,9 +13,7 @@ async function main() {
 
         let manifestStringData = fs.readFileSync(manifestPath, 'utf8');
         if (manifestStringData.startsWith('\uFEFF')) {
-            core.error("BOM character detected at the beginning of the manifest JSON file. " +
-                "Please remove the BOM from the file as it is not conform to the JSON spec: " +
-                "https://datatracker.ietf.org/doc/html/rfc7159#section-8.1")
+            core.warning("BOM character detected at the beginning of the manifest JSON file.\nPlease remove the BOM from the file as it is not conform to the JSON spec: https://datatracker.ietf.org/doc/html/rfc7159#section-8.1 and may cause issues regarding interoperability.")
             manifestStringData = manifestStringData.slice(1);
         }
 

--- a/main.js
+++ b/main.js
@@ -11,7 +11,16 @@ async function main() {
         const manifestPath = core.getInput("manifest");
         const extractPath = core.getInput("path");
 
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        let manifestStringData = fs.readFileSync(manifestPath, 'utf8');
+        if (manifestStringData.startsWith('\uFEFF')) {
+            core.error("BOM character detected at the beginning of the manifest JSON file. " +
+                "Please remove the BOM from the file as it is not conform to the JSON spec: " +
+                "https://datatracker.ietf.org/doc/html/rfc7159#section-8.1")
+            manifestStringData = manifestStringData.slice(1);
+        }
+
+        const manifest = JSON.parse(manifestStringData);
+
         core.info("Retrieved manifest of '" + manifest.id + "' version '" + manifest.version + "'");
 
         const gameVersions = await fetchJson("https://versions.beatmods.com/versions.json");


### PR DESCRIPTION
when the manifest file started with a BOM character (invisible control character), it would full-on crash the JSON.parse method.
This fix gracefully handles this issue, while also notifying the consumer that there is a potential issue and explaining why that could be an issue.

Other than that, changed the var keyword to either let/const keywords and fixed some type coercion.